### PR TITLE
Resolve option for function-as-data vs thunk

### DIFF
--- a/src/flow-compose/flow-function.ts
+++ b/src/flow-compose/flow-function.ts
@@ -12,8 +12,18 @@ import { isFlowArgument } from "./flow-argument";
 import { isComposedFlow } from "./flow-composed";
 import { markCachedRunner } from "./cached";
 
+export type FlowFunctionResolve = "thunk" | "value";
+
 export type FlowFunctionOptions = {
   cached?: boolean;
+  /**
+   * How to resolve the body's return value.
+   * - `"thunk"` (default): if the body returns a function, treat it as a deferred
+   *   factory — invoke it on consumer call, and cache per-args when `cached: true`.
+   * - `"value"`: return the body's result as-is, even when it is a function.
+   *   Use when the step's value is a function passed as data (mappers, predicates, callbacks).
+   */
+  resolve?: FlowFunctionResolve;
 };
 
 export function flowFunction<R, RunnersMap extends Runners = Runners>(
@@ -50,6 +60,7 @@ export function flowFunction<R, RunnersMap extends Runners = Runners>(
   }
 
   const isCached = options?.cached === true;
+  const resolveStrategy: FlowFunctionResolve = options?.resolve ?? "thunk";
 
   function invoker(runners: Runners) {
     const flowFunctionRunners: Runners = { ...runners };
@@ -77,7 +88,10 @@ export function flowFunction<R, RunnersMap extends Runners = Runners>(
       const cachedRunner = (...args: unknown[]): unknown => {
         if (!initialized) {
           const result = body(flowFunctionRunners as RunnersMap);
-          if (typeof result === "function") {
+          if (resolveStrategy === "value") {
+            behavior = "value";
+            cachedValue = result;
+          } else if (typeof result === "function") {
             behavior = "function";
             innerFn = result as (...args: unknown[]) => unknown;
             argCache = new Map();
@@ -110,7 +124,7 @@ export function flowFunction<R, RunnersMap extends Runners = Runners>(
 
     function runner(...args: unknown[]) {
       const result = body(flowFunctionRunners as RunnersMap);
-      if (typeof result === "function") {
+      if (resolveStrategy === "thunk" && typeof result === "function") {
         return (result as (...args: unknown[]) => unknown)(...args);
       }
       return result;

--- a/src/flow-compose/flow-property.ts
+++ b/src/flow-compose/flow-property.ts
@@ -7,26 +7,38 @@ import type {
   FlowFunctionInvoker,
   Runners,
 } from "./types";
-import { flowFunction } from "./flow-function";
+import { flowFunction, type FlowFunctionOptions } from "./flow-function";
+
+export type FlowPropertyOptions = Omit<FlowFunctionOptions, "cached">;
 
 export function flowProperty<R, RunnersMap extends Runners = Runners>(
   functionBody: FlowFunctionBody<R, RunnersMap>,
+  options?: FlowPropertyOptions,
 ): FlowFunctionInvoker<R>;
 export function flowProperty<R, RunnersMap extends Runners = Runners>(
   functionContext: Partial<FlowContext>,
   functionBody: FlowFunctionBody<R, RunnersMap>,
+  options?: FlowPropertyOptions,
 ): FlowFunctionInvoker<R>;
 export function flowProperty<R, RunnersMap extends Runners = Runners>(
   functionContextOrBody: Partial<FlowContext> | FlowFunctionBody<R, RunnersMap>,
-  maybeFunctionBody?: FlowFunctionBody<R, RunnersMap>,
+  maybeFunctionBody?: FlowFunctionBody<R, RunnersMap> | FlowPropertyOptions,
+  maybeOptions?: FlowPropertyOptions,
 ): FlowFunctionInvoker<R> {
   if (typeof functionContextOrBody === "function") {
-    return flowFunction(functionContextOrBody, { cached: true });
+    let propertyOptions: FlowPropertyOptions | undefined;
+    if (maybeFunctionBody !== undefined && typeof maybeFunctionBody !== "function") {
+      propertyOptions = maybeFunctionBody;
+    }
+    return flowFunction(functionContextOrBody, { cached: true, ...propertyOptions });
   }
 
   if (typeof maybeFunctionBody !== "function") {
     throw new Error("flowProperty requires a function body");
   }
 
-  return flowFunction(functionContextOrBody, maybeFunctionBody, { cached: true });
+  return flowFunction(functionContextOrBody, maybeFunctionBody, {
+    cached: true,
+    ...(maybeOptions ?? {}),
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,9 @@
 
 export type { FlowFunction } from "./flow-compose/types";
 export { flow, flowArgument, Flow } from "./flow-compose/flow";
-export { flowFunction } from "./flow-compose/flow-function";
-export { flowProperty } from "./flow-compose/flow-property";
+export {
+  flowFunction,
+  type FlowFunctionOptions,
+  type FlowFunctionResolve,
+} from "./flow-compose/flow-function";
+export { flowProperty, type FlowPropertyOptions } from "./flow-compose/flow-property";

--- a/tests/test_flow_function_resolve_value.test.ts
+++ b/tests/test_flow_function_resolve_value.test.ts
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import type { FlowFunction } from "../src";
+import { describe, expect, it, vi } from "vitest";
+import { flow } from "../src";
+import { flowFunction } from "../src";
+import { flowProperty } from "../src";
+
+type MapNumToNum = (n: number) => number;
+
+type CachedMapperCtx = { mapper: FlowFunction<MapNumToNum> };
+
+type GreetCtx = { greet: FlowFunction<void> };
+
+describe("flowFunction and flowProperty with resolve: \"value\"", () => {
+  it("caches a function value as data when cached and resolve is value", () => {
+    const bodySpy = vi.fn((): MapNumToNum => {
+      const inner = vi.fn((n: number) => n * 2);
+      return inner;
+    });
+
+    const mapperStep = flowFunction(bodySpy, { cached: true, resolve: "value" });
+
+    const useMapper = flowFunction(
+      ({ mapper }: CachedMapperCtx): void => {
+        const f1 = mapper();
+        const f2 = mapper();
+        expect(f1).toBe(f2);
+        expect(f1(5)).toBe(10);
+        expect(f1(3)).toBe(6);
+      },
+    );
+
+    const composed = flow(
+      { mapper: mapperStep, greet: useMapper },
+      flowFunction(({ greet }: GreetCtx): void => {
+        greet();
+      }),
+    );
+
+    composed();
+    expect(bodySpy).toHaveBeenCalledOnce();
+  });
+
+  it("re-runs the body on each consumer call when not cached and resolve is value", () => {
+    const bodySpy = vi.fn((): MapNumToNum => {
+      return (n: number) => n + 1;
+    });
+
+    const mapperStep = flowFunction(bodySpy, { resolve: "value" });
+
+    const useMapper = flowFunction(
+      ({ mapper }: CachedMapperCtx): void => {
+        const f1 = mapper();
+        const f2 = mapper();
+        expect(f1).not.toBe(f2);
+        expect(f1(1)).toBe(2);
+        expect(f2(1)).toBe(2);
+      },
+    );
+
+    const composed = flow(
+      { mapper: mapperStep, greet: useMapper },
+      flowFunction(({ greet }: GreetCtx): void => {
+        greet();
+      }),
+    );
+
+    composed();
+    expect(bodySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("flowProperty forwards resolve value for cached function-as-data", () => {
+    const bodySpy = vi.fn((): MapNumToNum => {
+      const inner = vi.fn((n: number) => n * 3);
+      return inner;
+    });
+
+    const mapperStep = flowProperty(bodySpy, { resolve: "value" });
+
+    const useMapper = flowFunction(
+      ({ mapper }: CachedMapperCtx): void => {
+        const f1 = mapper();
+        const f2 = mapper();
+        expect(f1).toBe(f2);
+        expect(f1(2)).toBe(6);
+      },
+    );
+
+    const composed = flow(
+      { mapper: mapperStep, greet: useMapper },
+      flowFunction(({ greet }: GreetCtx): void => {
+        greet();
+      }),
+    );
+
+    composed();
+    expect(bodySpy).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `resolve` option to `FlowFunctionOptions` so steps can return a **function as a cached value** without the library treating it as a **lazy thunk** (the previous default).

## Motivation

Today, `flowProperty` / `flowFunction({ cached: true })` treat a function returned from the body as a deferred factory: the consumer’s call invokes it, and results are memoized per consumer arguments. That is correct for patterns like `flowProperty(() => () => fetchStuff())` but awkward when the step’s value **is** a function passed as data (row mappers, predicates, callbacks). The usual workaround is wrapping in `{ run: fn }`, which leaks into types and call sites.

## What changed

- New type `FlowFunctionResolve = "thunk" | "value"` and optional `resolve` on `FlowFunctionOptions` (JSDoc describes behavior; default remains `"thunk"` for full backward compatibility).
- **Non-cached runner:** unwrap body result as a callable only when `resolve === "thunk"` and the result is a function; otherwise return the result as-is.
- **Cached runner:** when `resolve === "value"`, always store the body result in `cachedValue` (including functions); skip per-args thunk memoization.
- **`flowProperty`:** overloads accept optional `FlowPropertyOptions` (`Omit<FlowFunctionOptions, "cached">`); `cached: true` is still forced internally.
- **Exports:** `FlowFunctionOptions`, `FlowFunctionResolve`, `FlowPropertyOptions` from the package entry.

## Example

```ts
// Before (wrapper idiom)
const mapRow = flowProperty(() => ({ run: opts.mapRow }));
// consumer: mapRow().run

// After
const mapRow = flowProperty(() => opts.mapRow, { resolve: "value" });
// consumer: mapRow()